### PR TITLE
Add navigation and improve Material UI starter template

### DIFF
--- a/examples/material-ui-vite-tailwind-ts/src/App.tsx
+++ b/examples/material-ui-vite-tailwind-ts/src/App.tsx
@@ -3,6 +3,10 @@ import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import Link from '@mui/material/Link';
 import Slider from '@mui/material/Slider';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Divider from '@mui/material/Divider';
 import PopoverMenu from './PopoverMenu';
 import ProTip from './ProTip';
 
@@ -11,9 +15,7 @@ function Copyright() {
     <Typography
       variant="body2"
       align="center"
-      sx={{
-        color: 'text.secondary',
-      }}
+      sx={{ color: 'text.secondary' }}
     >
       {'Copyright © '}
       <Link color="inherit" href="https://mui.com/">
@@ -27,21 +29,45 @@ function Copyright() {
 
 export default function App() {
   return (
-    <Container maxWidth="sm">
-      <div className="my-4">
-        <Typography variant="h4" component="h1" sx={{ mb: 2 }}>
-          Material UI Vite example with Tailwind CSS in TypeScript
+    <Container maxWidth="md">
+      <Box
+        sx={{
+          my: 6,
+          px: { xs: 2, sm: 4 },
+          py: { xs: 4, sm: 6 },
+          textAlign: 'center',
+          borderRadius: 3,
+          background: 'linear-gradient(180deg, hsl(210, 20%, 98%) 0%, #fff 100%)',
+        }}
+      >
+        <Typography variant="h3" component="h1" sx={{ fontWeight: 600, mb: 1 }}>
+          Material UI Starter Template
         </Typography>
-        <Slider
-          className="my-4"
-          defaultValue={30}
-          classes={{ active: 'shadow-none' }}
-          slotProps={{ thumb: { className: 'hover:shadow-none' } }}
-        />
-        <PopoverMenu />
+        <Typography variant="subtitle1" sx={{ color: 'text.secondary', mb: 4 }}>
+          A clean, light starting point for future prototypes.
+        </Typography>
+
+        <Paper elevation={2} sx={{ p: { xs: 2, sm: 3 }, maxWidth: 560, mx: 'auto', mb: 4 }}>
+          <Stack spacing={2} alignItems="stretch">
+            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+              Try the components:
+            </Typography>
+            <Slider
+              className="my-1"
+              defaultValue={30}
+              classes={{ active: 'shadow-none' }}
+              slotProps={{ thumb: { className: 'hover:shadow-none' } }}
+            />
+            <Stack direction="row" spacing={1} justifyContent="center">
+              <PopoverMenu />
+            </Stack>
+          </Stack>
+        </Paper>
+
         <ProTip />
+        <Divider sx={{ my: 2 }} />
         <Copyright />
-      </div>
+      </Box>
     </Container>
   );
 }

--- a/examples/material-ui-vite-tailwind-ts/src/App.tsx
+++ b/examples/material-ui-vite-tailwind-ts/src/App.tsx
@@ -66,10 +66,10 @@ function HomeSection() {
       }}
     >
       <Typography variant="h3" component="h1" sx={{ fontWeight: 600, mb: 1 }}>
-        Material UI Starter Template
+        Starter Template
       </Typography>
       <Typography variant="subtitle1" sx={{ color: 'text.secondary', mb: 4 }}>
-        A clean, light starting point for future prototypes.
+        A clean, light starting point for future ideas + prototypes.
       </Typography>
       <ProTip />
       <Divider sx={{ my: 2 }} />
@@ -124,7 +124,7 @@ export default function App() {
             Material UI Starter Template
           </Typography>
           <Button color="primary" onClick={() => navigate('home')} href="#/">Home</Button>
-          <Button color="primary" onClick={() => navigate('components')} href="#/components">Components</Button>
+          <Button color="primary" onClick={() => navigate('components')} href="#/components">SHOWCASE</Button>
           <Button color="primary" onClick={() => navigate('about')} href="#/about">About</Button>
         </Toolbar>
       </AppBar>

--- a/examples/material-ui-vite-tailwind-ts/src/App.tsx
+++ b/examples/material-ui-vite-tailwind-ts/src/App.tsx
@@ -7,6 +7,9 @@ import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Divider from '@mui/material/Divider';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import Button from '@mui/material/Button';
 import PopoverMenu from './PopoverMenu';
 import ProTip from './ProTip';
 
@@ -27,47 +30,110 @@ function Copyright() {
   );
 }
 
-export default function App() {
+type Route = 'home' | 'components' | 'about';
+
+function useHashRoute(): [Route, (r: Route) => void] {
+  const parse = (): Route => {
+    const h = window.location.hash.replace(/^#\/?/, '');
+    if (h.startsWith('components')) return 'components';
+    if (h.startsWith('about')) return 'about';
+    return 'home';
+  };
+  const [route, setRoute] = React.useState<Route>(parse);
+  React.useEffect(() => {
+    const onChange = () => setRoute(parse());
+    window.addEventListener('hashchange', onChange);
+    return () => window.removeEventListener('hashchange', onChange);
+  }, []);
+  const navigate = (r: Route) => {
+    const path = r === 'home' ? '#/' : `#/${r}`;
+    if (window.location.hash !== path) window.location.hash = path;
+    setRoute(r);
+  };
+  return [route, navigate];
+}
+
+function HomeSection() {
   return (
-    <Container maxWidth="md">
-      <Box
-        sx={{
-          my: 6,
-          px: { xs: 2, sm: 4 },
-          py: { xs: 4, sm: 6 },
-          textAlign: 'center',
-          borderRadius: 3,
-          background: 'linear-gradient(180deg, hsl(210, 20%, 98%) 0%, #fff 100%)',
-        }}
-      >
-        <Typography variant="h3" component="h1" sx={{ fontWeight: 600, mb: 1 }}>
-          Material UI Starter Template
-        </Typography>
-        <Typography variant="subtitle1" sx={{ color: 'text.secondary', mb: 4 }}>
-          A clean, light starting point for future prototypes.
-        </Typography>
+    <Box
+      sx={{
+        my: 6,
+        px: { xs: 2, sm: 4 },
+        py: { xs: 4, sm: 6 },
+        textAlign: 'center',
+        borderRadius: 3,
+        background: 'linear-gradient(180deg, hsl(210, 20%, 98%) 0%, #fff 100%)',
+      }}
+    >
+      <Typography variant="h3" component="h1" sx={{ fontWeight: 600, mb: 1 }}>
+        Material UI Starter Template
+      </Typography>
+      <Typography variant="subtitle1" sx={{ color: 'text.secondary', mb: 4 }}>
+        A clean, light starting point for future prototypes.
+      </Typography>
+      <ProTip />
+      <Divider sx={{ my: 2 }} />
+      <Copyright />
+    </Box>
+  );
+}
 
-        <Paper elevation={2} sx={{ p: { xs: 2, sm: 3 }, maxWidth: 560, mx: 'auto', mb: 4 }}>
-          <Stack spacing={2} alignItems="stretch">
-            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-              Try the components:
-            </Typography>
-            <Slider
-              className="my-1"
-              defaultValue={30}
-              classes={{ active: 'shadow-none' }}
-              slotProps={{ thumb: { className: 'hover:shadow-none' } }}
-            />
-            <Stack direction="row" spacing={1} justifyContent="center">
-              <PopoverMenu />
-            </Stack>
+function ComponentsSection() {
+  return (
+    <Box sx={{ my: 6 }}>
+      <Paper elevation={2} sx={{ p: { xs: 2, sm: 3 }, maxWidth: 560, mx: 'auto', mb: 4 }}>
+        <Stack spacing={2} alignItems="stretch">
+          <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+            Try the components:
+          </Typography>
+          <Slider
+            className="my-1"
+            defaultValue={30}
+            classes={{ active: 'shadow-none' }}
+            slotProps={{ thumb: { className: 'hover:shadow-none' } }}
+          />
+          <Stack direction="row" spacing={1} justifyContent="center">
+            <PopoverMenu />
           </Stack>
-        </Paper>
+        </Stack>
+      </Paper>
+    </Box>
+  );
+}
 
-        <ProTip />
-        <Divider sx={{ my: 2 }} />
-        <Copyright />
-      </Box>
-    </Container>
+function AboutSection() {
+  return (
+    <Box sx={{ my: 6, textAlign: 'center' }}>
+      <Typography variant="h5" sx={{ mb: 1 }}>
+        About
+      </Typography>
+      <Typography color="text.secondary">
+        This starter helps you spin up quick prototypes with Material UI and Vite.
+      </Typography>
+    </Box>
+  );
+}
+
+export default function App() {
+  const [route, navigate] = useHashRoute();
+  return (
+    <Box>
+      <AppBar position="sticky" color="inherit" elevation={0} sx={{ borderBottom: '1px solid', borderColor: 'divider' }}>
+        <Toolbar sx={{ gap: 1 }}>
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            Material UI Starter Template
+          </Typography>
+          <Button color="primary" onClick={() => navigate('home')} href="#/">Home</Button>
+          <Button color="primary" onClick={() => navigate('components')} href="#/components">Components</Button>
+          <Button color="primary" onClick={() => navigate('about')} href="#/about">About</Button>
+        </Toolbar>
+      </AppBar>
+
+      <Container maxWidth="md">
+        {route === 'home' && <HomeSection />}
+        {route === 'components' && <ComponentsSection />}
+        {route === 'about' && <AboutSection />}
+      </Container>
+    </Box>
   );
 }

--- a/examples/material-ui-vite-tailwind-ts/src/main.tsx
+++ b/examples/material-ui-vite-tailwind-ts/src/main.tsx
@@ -2,9 +2,18 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+
+const theme = createTheme({
+  palette: { mode: 'light' },
+});
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Purpose

Transform the basic Material UI example into a proper starter template with improved visual appeal and navigation. The user wanted to create a clean, light-themed shell app called "Material UI Starter Template" that serves as a foundation for future prototypes, with added navigation and sample routes to make it more functional.

## Code changes

- **Navigation**: Added top navigation bar with AppBar and Toolbar containing Home, Showcase, and About links
- **Routing**: Implemented hash-based routing system with `useHashRoute` hook to handle navigation between sections
- **Layout restructure**: Split content into three distinct sections (HomeSection, ComponentsSection, AboutSection)
- **Theme setup**: Added light theme configuration with ThemeProvider and CssBaseline in main.tsx
- **Visual improvements**: Enhanced styling with gradient backgrounds, better spacing, and Paper components for card-like layouts
- **Component organization**: Moved existing components (Slider, PopoverMenu) into dedicated showcase section
- **Branding**: Updated title to "Material UI Starter Template" throughout the interfaceTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d4ab2c632db84135ab221c8d1e5b6e7a/spark-haven)

👀 [Preview Link](https://d4ab2c632db84135ab221c8d1e5b6e7a-spark-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d4ab2c632db84135ab221c8d1e5b6e7a</projectId>-->
<!--<branchName>spark-haven</branchName>-->